### PR TITLE
Add padded url safe base64 encoding  `b64_url_pad` for random_id outputs

### DIFF
--- a/docs/resources/id.md
+++ b/docs/resources/id.md
@@ -73,7 +73,8 @@ resource "aws_instance" "server" {
 ### Read-Only
 
 - `b64_std` (String) The generated id presented in base64 without additional transformations.
-- `b64_url` (String) The generated id presented in base64, using the URL-friendly character set: case-sensitive letters, digits and the characters `_` and `-`.
+- `b64_url` (String) The generated id presented in non-padded base64, using the URL-friendly character set: case-sensitive letters, digits and the characters `_` and `-`.
+- `b64_url_pad` (String) The generated id presented in padded base64, using the URL-friendly character set: case-sensitive letters, digits, padding with `=` and the characters `_` and `-`.
 - `dec` (String) The generated id presented in non-padded decimal digits.
 - `hex` (String) The generated id presented in padded hexadecimal digits. This result will always be twice as long as the requested byte length.
 - `id` (String) The generated id presented in base64 without additional transformations or prefix.

--- a/internal/provider/resource_id.go
+++ b/internal/provider/resource_id.go
@@ -85,6 +85,14 @@ exist concurrently.
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"b64_url_pad": schema.StringAttribute{
+				Description: "The generated id presented in padded base64, using the URL-friendly character set: " +
+					"case-sensitive letters, digits, padding with `=` and the characters `_` and `-`.",
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"b64_std": schema.StringAttribute{
 				Description: "The generated id presented in base64 without additional transformations.",
 				Computed:    true,
@@ -141,6 +149,7 @@ func (r *idResource) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	id := base64.RawURLEncoding.EncodeToString(bytes)
+	b64urlWithPading := base64.URLEncoding.EncodeToString(bytes)
 	prefix := plan.Prefix.ValueString()
 	b64Std := base64.StdEncoding.EncodeToString(bytes)
 	hexStr := hex.EncodeToString(bytes)
@@ -155,6 +164,7 @@ func (r *idResource) Create(ctx context.Context, req resource.CreateRequest, res
 		ByteLength: types.Int64Value(plan.ByteLength.ValueInt64()),
 		Prefix:     plan.Prefix,
 		B64URL:     types.StringValue(prefix + id),
+		B64URLPad:  types.StringValue(prefix + b64urlWithPading),
 		B64Std:     types.StringValue(prefix + b64Std),
 		Hex:        types.StringValue(prefix + hexStr),
 		Dec:        types.StringValue(prefix + dec),
@@ -210,6 +220,7 @@ func (r *idResource) ImportState(ctx context.Context, req resource.ImportStateRe
 		return
 	}
 
+	b64urlWithPading := base64.URLEncoding.EncodeToString(bytes)
 	b64Std := base64.StdEncoding.EncodeToString(bytes)
 	hexStr := hex.EncodeToString(bytes)
 
@@ -225,6 +236,7 @@ func (r *idResource) ImportState(ctx context.Context, req resource.ImportStateRe
 	state.Keepers = types.MapValueMust(types.StringType, nil)
 	state.B64Std = types.StringValue(prefix + b64Std)
 	state.B64URL = types.StringValue(prefix + id)
+	state.B64URLPad = types.StringValue(prefix + b64urlWithPading)
 	state.Hex = types.StringValue(prefix + hexStr)
 	state.Dec = types.StringValue(prefix + dec)
 
@@ -247,6 +259,7 @@ type idModelV0 struct {
 	ByteLength types.Int64  `tfsdk:"byte_length"`
 	Prefix     types.String `tfsdk:"prefix"`
 	B64URL     types.String `tfsdk:"b64_url"`
+	B64URLPad  types.String `tfsdk:"b64_url_pad"`
 	B64Std     types.String `tfsdk:"b64_std"`
 	Hex        types.String `tfsdk:"hex"`
 	Dec        types.String `tfsdk:"dec"`

--- a/internal/provider/resource_id_test.go
+++ b/internal/provider/resource_id_test.go
@@ -16,6 +16,7 @@ func TestAccResourceID(t *testing.T) {
 						}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrWith("random_id.foo", "b64_url", testCheckLen(6)),
+					resource.TestCheckResourceAttrWith("random_id.foo", "b64_url_pad", testCheckLen(8)),
 					resource.TestCheckResourceAttrWith("random_id.foo", "b64_std", testCheckLen(8)),
 					resource.TestCheckResourceAttrWith("random_id.foo", "hex", testCheckLen(8)),
 					resource.TestCheckResourceAttrWith("random_id.foo", "dec", testCheckMinLen(1)),
@@ -41,6 +42,7 @@ func TestAccResourceID_ImportWithPrefix(t *testing.T) {
 						}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrWith("random_id.bar", "b64_url", testCheckLen(12)),
+					resource.TestCheckResourceAttrWith("random_id.bar", "b64_url_pad", testCheckLen(14)),
 					resource.TestCheckResourceAttrWith("random_id.bar", "b64_std", testCheckLen(14)),
 					resource.TestCheckResourceAttrWith("random_id.bar", "hex", testCheckLen(14)),
 					resource.TestCheckResourceAttrWith("random_id.bar", "dec", testCheckMinLen(1)),
@@ -67,6 +69,7 @@ func TestAccResourceID_UpgradeFromVersion3_3_2(t *testing.T) {
 						}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrWith("random_id.bar", "b64_url", testCheckLen(12)),
+					resource.TestCheckResourceAttrWith("random_id.bar", "b64_url_pad", testCheckLen(14)),
 					resource.TestCheckResourceAttrWith("random_id.bar", "b64_std", testCheckLen(14)),
 					resource.TestCheckResourceAttrWith("random_id.bar", "hex", testCheckLen(14)),
 					resource.TestCheckResourceAttrWith("random_id.bar", "dec", testCheckMinLen(1)),
@@ -88,6 +91,7 @@ func TestAccResourceID_UpgradeFromVersion3_3_2(t *testing.T) {
 						}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrWith("random_id.bar", "b64_url", testCheckLen(12)),
+					resource.TestCheckResourceAttrWith("random_id.bar", "b64_url_pad", testCheckLen(14)),
 					resource.TestCheckResourceAttrWith("random_id.bar", "b64_std", testCheckLen(14)),
 					resource.TestCheckResourceAttrWith("random_id.bar", "hex", testCheckLen(14)),
 					resource.TestCheckResourceAttrWith("random_id.bar", "dec", testCheckMinLen(1)),


### PR DESCRIPTION
# proposal
I added `b64_url_pad` for random_id output.

## Why

When creating a signed URL for CloudCDN, I used  `random_id b64_url`.
[google_compute_backend_bucket_signed_url_key | Resources | hashicorp/google | Terraform Registry](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_bucket_signed_url_key)
```terraform
resource "random_id" "url_signature" {
  byte_length = 16
}

resource "google_compute_backend_bucket_signed_url_key" "backend_key" {
  name           = "test-key"
  key_value      = random_id.url_signature.b64_url
  backend_bucket = google_compute_backend_bucket.test_backend.name
}
```
I have confirmed that this works.
However, when I created them from the Google Cloud console or the `gcloud` command, the keys created were URL safe, base64 encoded, and **_padded with `=`_**.

Furthermore, the official Google Cloud sample code assumes the padded keys, so I could not use the keys created with b64_url without modification. In addition, when I tried to create a signed URL using the `gcloud compute sign-url` command, an error occurred because it used a key without padding.

failed gcloud command
```sh
> gcloud compute sign-url \
  "https://example.com/test.png" \
  --key-name test-key \
  --key-file key-file \
  --expires-in 5m \
  --validate
ERROR: gcloud crashed (Error): Incorrect padding

If you would like to report this issue, please run the following command:
  gcloud feedback

To check gcloud for common problems, please run the following command:
  gcloud info --run-diagnostics
```

fixed google cloud sample code for golang
[Use signed URLs  |  Cloud CDN  |  Google Cloud](https://cloud.google.com/cdn/docs/using-signed-urls?hl=en#gcloud_1)
```diff
// readKeyFile reads the base64url-encoded key file and decodes it.
func readKeyFile(path string) ([]byte, error) {
        b, err := ioutil.ReadFile(path)
        if err != nil {
                return nil, fmt.Errorf("failed to read key file: %+v", err)
        }
-       d := make([]byte, base64.URLEncoding.DecodedLen(len(b)))
-       n, err := base64.URLEncoding.Decode(d, b)
+       d := make([]byte, base64.RawURLEncoding.DecodedLen(len(b)))
+       n, err := base64.RawURLEncoding.Decode(d, b)
        if err != nil {
                return nil, fmt.Errorf("failed to base64url decode: %+v", err)
        }
        return d[:n], nil
}

```

## Change

before
```terraform
resource "random_id" "url_signature" {
  byte_length = 16
}

resource "google_compute_backend_bucket_signed_url_key" "backend_key" {
  name           = "test-key"
  key_value      = random_id.url_signature.b64_url
  backend_bucket = google_compute_backend_bucket.test_backend.name
}
```

after

```terraform
resource "random_id" "url_signature" {
  byte_length = 16
}

resource "google_compute_backend_bucket_signed_url_key" "backend_key" {
  name           = "test-key"
  key_value      = random_id.url_signature.b64_url_pad
  backend_bucket = google_compute_backend_bucket.test_backend.name
}
```

## Name
At first, I thought of changing the output of b64_url to have padding and creating a new b64_raw_url with no padding.
The reason is that Go code also uses `base64.URLEncoding` to encode those with padding and `base64.RawURLEncoding` for those without padding.

The reason for using `b64_url_pad` instead of `b64_raw_url` is to avoid modifying the already used `b64_url`.
In the long run, I think it is better to add `b64_raw_url`, but if you accept this PR, I would appreciate your consideration.

